### PR TITLE
fix e2e test by adding status subresource support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ container:
 test:
 	./go.test.sh
 
-e2e: 
+e2e: build container
 	operator-sdk test local ./test/e2e
 
 push: container

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: kanary
       containers:
         - name: kanary
-          image: kanary/operator:v0.0.1
+          image: kanary/operator:latest
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
So far the switch between usage of subresource or not is done using env variable:
`os.Getenv("SUBRESOURCE_DISABLED") == "1"`