### PR TITLE
add auth dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -394,9 +394,12 @@
   digest = "1:ec2a29e3bd141038ae5c3d3a4f57db0c341fcc1d98055a607aedd683aed124ee"
   name = "github.com/prometheus/client_golang"
   packages = [
+    "api",
+    "api/prometheus/v1",
     "prometheus",
     "prometheus/internal",
     "prometheus/promhttp",
+    "prometheus/push",
   ]
   pruneopts = "NT"
   revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
@@ -809,6 +812,7 @@
     "kubernetes/typed/storage/v1",
     "kubernetes/typed/storage/v1alpha1",
     "kubernetes/typed/storage/v1beta1",
+    "listers/core/v1",
     "pkg/apis/clientauthentication",
     "pkg/apis/clientauthentication/v1alpha1",
     "pkg/apis/clientauthentication/v1beta1",
@@ -968,6 +972,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/blang/semver",
     "github.com/ghodss/yaml",
     "github.com/go-logr/logr",
     "github.com/olekukonko/tablewriter",
@@ -977,6 +982,11 @@
     "github.com/operator-framework/operator-sdk/pkg/test",
     "github.com/operator-framework/operator-sdk/pkg/test/e2eutil",
     "github.com/operator-framework/operator-sdk/version",
+    "github.com/prometheus/client_golang/api",
+    "github.com/prometheus/client_golang/api/prometheus/v1",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/push",
+    "github.com/prometheus/common/model",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
     "k8s.io/api/apps/v1beta1",
@@ -988,14 +998,21 @@
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/errors",
+    "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apimachinery/pkg/version",
     "k8s.io/cli-runtime/pkg/genericclioptions",
+    "k8s.io/client-go/discovery",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",
+    "k8s.io/client-go/listers/core/v1",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
+    "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/util/workqueue",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/conversion-gen",
     "k8s.io/code-generator/cmd/deepcopy-gen",
@@ -1010,6 +1027,7 @@
     "sigs.k8s.io/controller-runtime/pkg/client/fake",
     "sigs.k8s.io/controller-runtime/pkg/controller",
     "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil",
+    "sigs.k8s.io/controller-runtime/pkg/event",
     "sigs.k8s.io/controller-runtime/pkg/handler",
     "sigs.k8s.io/controller-runtime/pkg/manager",
     "sigs.k8s.io/controller-runtime/pkg/reconcile",

--- a/cmd/kubectl-kanary/main.go
+++ b/cmd/kubectl-kanary/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"github.com/amadeusitgroup/kanary/pkg/plugin"
 )


### PR DESCRIPTION
When trying to go through README while connected to GKE cluster, I get the following error:

```
$ kubectl kanary generate myapp --name=superman --traffic=both --service=myapp-svc --validation-period=1m -oyaml
panic: No Auth Provider found for name "gcp"

goroutine 1 [running]:
github.com/AmadeusITGroup/kanary/vendor/k8s.io/client-go/discovery.NewDiscoveryClientForConfigOrDie(...)
	/go/src/github.com/AmadeusITGroup/kanary/vendor/k8s.io/client-go/discovery/discovery_client.go:454
github.com/AmadeusITGroup/kanary/vendor/sigs.k8s.io/controller-runtime/pkg/client/apiutil.NewDiscoveryRESTMapper(0xc0003ffdc0, 0xc0003ffdc0, 0x0, 0x0, 0x10ea9a0)
	/go/src/github.com/AmadeusITGroup/kanary/vendor/sigs.k8s.io/controller-runtime/pkg/client/apiutil/apimachinery.go:35 +0xda
github.com/AmadeusITGroup/kanary/vendor/github.com/amadeusitgroup/kanary/pkg/plugin.NewClient(0x1324ac0, 0xc0002d6780, 0xc0002d6780, 0x1a, 0xc0002121c0, 0xc00012bd58)
	/go/src/github.com/AmadeusITGroup/kanary/vendor/github.com/amadeusitgroup/kanary/pkg/plugin/client.go:23 +0x15a
github.com/AmadeusITGroup/kanary/vendor/github.com/amadeusitgroup/kanary/pkg/plugin.(*generateOptions).Complete(0xc0002b3200, 0xc0002e8f00, 0xc0002daa20, 0x1, 0x6, 0xc00012bd10, 0x0)
	/go/src/github.com/AmadeusITGroup/kanary/vendor/github.com/amadeusitgroup/kanary/pkg/plugin/generate.go:166 +0x85
github.com/AmadeusITGroup/kanary/vendor/github.com/amadeusitgroup/kanary/pkg/plugin.NewCmdGenerate.func1(0xc0002e8f00, 0xc0002daa20, 0x1, 0x6, 0x0, 0x0)
	/go/src/github.com/AmadeusITGroup/kanary/vendor/github.com/amadeusitgroup/kanary/pkg/plugin/generate.go:133 +0x5b
github.com/AmadeusITGroup/kanary/vendor/github.com/spf13/cobra.(*Command).execute(0xc0002e8f00, 0xc0002da9c0, 0x6, 0x6, 0xc0002e8f00, 0xc0002da9c0)
	/go/src/github.com/AmadeusITGroup/kanary/vendor/github.com/spf13/cobra/command.go:762 +0x465
github.com/AmadeusITGroup/kanary/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc0002e8c80, 0xc0000b6000, 0x12faa00, 0xc0000b6008)
	/go/src/github.com/AmadeusITGroup/kanary/vendor/github.com/spf13/cobra/command.go:852 +0x2ec
github.com/AmadeusITGroup/kanary/vendor/github.com/spf13/cobra.(*Command).Execute(...)
	/go/src/github.com/AmadeusITGroup/kanary/vendor/github.com/spf13/cobra/command.go:800
main.main()
	/go/src/github.com/AmadeusITGroup/kanary/cmd/kubectl-kanary/main.go:18 +0x110
```

I have added auth package as side-effects dependency and run `dep ensure` and now its not returning the error.