### PR TITLE
fix building operator-sdk

### DIFF
--- a/hack/install-operator-sdk.sh
+++ b/hack/install-operator-sdk.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
 set -e
-
-go get -u github.com/golang/dep/cmd/dep
 mkdir -p $GOPATH/src/github.com/operator-framework
 cd $GOPATH/src/github.com/operator-framework
 git clone https://github.com/operator-framework/operator-sdk
 cd operator-sdk
 git checkout master
-make dep
 make install


### PR DESCRIPTION
operator-sdk removed the usage of **dep** 21h ago. The target "**dep**" doesn't exist anymore. 

**Suggestion**: the version of the operator-sdk used shoud be fixed to avoid such situation again and to be sure to have a stable CI and build
At least it should used the same version than the one used in the dependency : 
```
github.com/operator-framework/operator-sdk v0.0.0-20181217150934-209ac08a5696
```